### PR TITLE
Disable two tests for Clang 14+ targeting SPIR-V

### DIFF
--- a/tests/catch/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessor.cc
+++ b/tests/catch/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessor.cc
@@ -80,6 +80,21 @@ TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_rangeValidation") {
   REQUIRE((numBlock * blockSize) <= devProp.maxThreadsPerMultiProcessor);
 }
 
+#if defined(__HIP_PLATFORM_SPIRV__) && defined(__clang__) && __clang_major__ >= 14
+// This test case is known to fail on clang-14 for SPIR-V
+// target. Building this case fails with the following error message:
+//
+// .../HIP/tests/catch/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessor.cc:87:13: error: no matching function for call to 'hipOccupancyMaxActiveBlocksPerMultiprocessor'
+//   HIP_CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor<void(*)(int *)>
+//             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// .../HIP/tests/catch/./include/hip_test_common.hh:31:29: note: expanded from macro 'HIP_CHECK'
+//     hipError_t localError = error;                                                                 \
+//                             ^~~~~
+// .../HIP/include/hip/hip_runtime_api.h:5238:19: note: candidate function template not viable: no overload of 'f2' matching 'void (*)(int *)' for 2nd argument
+// inline hipError_t hipOccupancyMaxActiveBlocksPerMultiprocessor(int* numBlocks, T f, int blockSize,
+//                   ^
+#  warning Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_templateInvocation is disabled for clang-14+ 
+#else
 TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_templateInvocation") {
   int blockSize = 32;
   int numBlock = 0;
@@ -88,4 +103,4 @@ TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_templateInvocation"
                                                   (&numBlock, f2, blockSize, 0));
   REQUIRE(numBlock > 0);
 }
-
+#endif

--- a/tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSize.cc
+++ b/tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSize.cc
@@ -69,6 +69,24 @@ TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_rangeValidation") {
 
 }
 
+#if defined(__HIP_PLATFORM_SPIRV__) && defined(__clang__) && __clang_major__ >= 14
+// This test case is known to fail on clang-14 for SPIR-V
+// target. Building this case fails with the following error message:
+//
+// .../HIP/tests/catch/unit/occupancy/hipO// ccupancyMaxPotentialBlockSize.cc:75:13: error: no matching function for call to 'hipOccupancyMaxPotentialBlockSize'
+//   HIP_CHECK(hipOccupancyMaxPotentialBlockSize<void(*)(int *)>(&gridSize,
+//             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// .../HIP/tests/catch/./include/hip_test_common.hh:31:29: note: expanded from macro 'HIP_CHECK'
+//     hipError_t localError = error;                                                                 \
+//                             ^~~~~
+// .../HIP/include/hip/hip_runtime_api.h:5194:35: note: candidate function template not viable: no overload of 'f2' matching 'void (*)(int *)' for 3rd argument
+// static hipError_t __host__ inline hipOccupancyMaxPotentialBlockSize(int* gridSize, int* blockSize,
+//                                   ^
+// .../HIP/include/hip/hip_runtime_api.h:5252:19: note: candidate function template not viable: no overload of 'f2' matching 'void (*)(int *)' for 3rd argument
+// inline hipError_t hipOccupancyMaxPotentialBlockSize(int* gridSize, int* blockSize, F kernel,
+//                   ^
+#  warning Unit_hipOccupancyMaxPotentialBlockSize_templateInvocation is disabled for clang-14+
+#else
 TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_templateInvocation") {
   int gridSize = 0, blockSize = 0;
 
@@ -77,4 +95,4 @@ TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_templateInvocation") {
   REQUIRE(gridSize > 0);
   REQUIRE(blockSize > 0);
 }
-
+#endif


### PR DESCRIPTION
Two test cases fail to build with clang-14 due to a bug in the
compiler. Disable them until a fix is introduced.