### PR TITLE
Add canMapHostMemory and managedMemory skip guards to catch tests

### DIFF
--- a/tests/catch/unit/compiler/hipClassKernel.cc
+++ b/tests/catch/unit/compiler/hipClassKernel.cc
@@ -202,6 +202,12 @@ passByValueKernel(testPassByValue obj, bool* result_ecd) {
 }
 
 TEST_CASE("Unit_hipClassKernel_Value") {
+  hipDeviceProp_t prop;
+  HIP_CHECK(hipGetDeviceProperties(&prop, 0));
+  if (!prop.canMapHostMemory) {
+    HipTest::HIP_SKIP_TEST("Test requires canMapHostMemory support");
+    return;
+  }
   bool *result_ecd,*result_ech;
   result_ech = AllocateHostMemory();
   result_ecd = AllocateDeviceMemory();

--- a/tests/catch/unit/kernel/hipMemFaultStackAllocation.cc
+++ b/tests/catch/unit/kernel/hipMemFaultStackAllocation.cc
@@ -64,6 +64,13 @@ static bool verify(const int* C_d, const int* A_d) {
 }
 
 TEST_CASE("Unit_hipMemFaultStackAllocation_Check") {
+  int managedSupport = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&managedSupport,
+                                  hipDeviceAttributeManagedMemory, 0));
+  if (!managedSupport) {
+    HipTest::HIP_SKIP_TEST("Device does not support managed memory");
+    return;
+  }
   hipError_t ret;
   int *A_d, *C_d;
   const size_t Nbytes = N * sizeof(int);

--- a/tests/catch/unit/memory/hipHostGetDevicePointer.cc
+++ b/tests/catch/unit/memory/hipHostGetDevicePointer.cc
@@ -43,6 +43,12 @@ TEST_CASE("Unit_hipHostGetDevicePointer_Negative") {
 template <typename T> __global__ void set(T* ptr, T val) { *ptr = val; }
 
 TEST_CASE("Unit_hipHostGetDevicePointer_UseCase") {
+  hipDeviceProp_t prop;
+  HIP_CHECK(hipGetDeviceProperties(&prop, 0));
+  if (!prop.canMapHostMemory) {
+    HipTest::HIP_SKIP_TEST("Test requires canMapHostMemory support");
+    return;
+  }
   int* hPtr{nullptr};
   HIP_CHECK(hipHostMalloc(&hPtr, sizeof(int)));
 

--- a/tests/catch/unit/memory/hipHostMalloc.cc
+++ b/tests/catch/unit/memory/hipHostMalloc.cc
@@ -172,6 +172,12 @@ This testcase verifies the hipHostMalloc API by
 3. validates the result.
 */
 TEST_CASE("Unit_hipHostMalloc_NonCoherent") {
+  hipDeviceProp_t prop;
+  HIP_CHECK(hipGetDeviceProperties(&prop, 0));
+  if (!prop.canMapHostMemory) {
+    HipTest::HIP_SKIP_TEST("Test requires canMapHostMemory support");
+    return;
+  }
   int* A = nullptr;
   HIP_CHECK(hipHostMalloc(reinterpret_cast<void**>(&A),
                           sizeBytes, hipHostMallocNonCoherent));
@@ -224,6 +230,12 @@ This testcase verifies the hipHostMalloc API by
 3. validates the result.
 */
 TEST_CASE("Unit_hipHostMalloc_Default") {
+  hipDeviceProp_t prop;
+  HIP_CHECK(hipGetDeviceProperties(&prop, 0));
+  if (!prop.canMapHostMemory) {
+    HipTest::HIP_SKIP_TEST("Test requires canMapHostMemory support");
+    return;
+  }
   int* A = nullptr;
   HIP_CHECK(hipHostMalloc(reinterpret_cast<void**>(&A), sizeBytes));
   const char* ptrType = "default";

--- a/tests/catch/unit/memory/hipMallocManaged.cc
+++ b/tests/catch/unit/memory/hipMallocManaged.cc
@@ -60,9 +60,8 @@ static unsigned threadsPerBlock{256};
 TEST_CASE("Unit_hipMallocManaged_Basic") {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    WARN(
-        "GPU doesn't support hipDeviceAttributeManagedMemory attribute so defaulting to system "
-        "memory.");
+    HipTest::HIP_SKIP_TEST("GPU doesn't support managed memory");
+    return;
   }
 
   float *A, *B, *C;

--- a/tests/catch/unit/memory/hipMemPrefetchAsyncExtTsts.cc
+++ b/tests/catch/unit/memory/hipMemPrefetchAsyncExtTsts.cc
@@ -322,6 +322,13 @@ TEST_CASE("Unit_hipMemPrefetchAsyncNegativeTst") {
    which is not multiple of page Size, but still trying to launch kernel and
    see if we are getting values as expected.*/
 TEST_CASE("Unit_hipMemPrefetchAsync_NonPageSz") {
+  int managedSupport = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&managedSupport,
+                                  hipDeviceAttributeManagedMemory, 0));
+  if (!managedSupport) {
+    HipTest::HIP_SKIP_TEST("Device does not support managed memory");
+    return;
+  }
   int *Hmm = nullptr, NumElms = 4096*2, InitVal = 123;
   hipStream_t strm;
   bool IfTestPassed = true;

--- a/tests/catch/unit/memory/hipMemcpy.cc
+++ b/tests/catch/unit/memory/hipMemcpy.cc
@@ -438,6 +438,12 @@ This testcase verifies the following scenarios
 */
 TEMPLATE_TEST_CASE("Unit_hipMemcpy_H2H-H2D-D2H-H2PinMem", "", int,
                    float, double) {
+  hipDeviceProp_t prop;
+  HIP_CHECK(hipGetDeviceProperties(&prop, 0));
+  if (!prop.canMapHostMemory) {
+    HipTest::HIP_SKIP_TEST("Test requires canMapHostMemory support");
+    return;
+  }
   TestType *A_d{nullptr}, *B_d{nullptr};
   TestType *A_h{nullptr}, *B_h{nullptr};
   TestType *A_Ph{nullptr}, *B_Ph{nullptr};

--- a/tests/catch/unit/memory/hipMemcpyAsync.cc
+++ b/tests/catch/unit/memory/hipMemcpyAsync.cc
@@ -142,6 +142,12 @@ This testcase verifies the following scenarios
 */
 TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_H2H-H2D-D2H-H2PinMem", "", char, int,
                    float, double) {
+  hipDeviceProp_t prop;
+  HIP_CHECK(hipGetDeviceProperties(&prop, 0));
+  if (!prop.canMapHostMemory) {
+    HipTest::HIP_SKIP_TEST("Test requires canMapHostMemory support");
+    return;
+  }
   TestType *A_d{nullptr}, *B_d{nullptr};
   TestType *A_h{nullptr}, *B_h{nullptr};
   TestType *A_Ph{nullptr}, *B_Ph{nullptr};

--- a/tests/catch/unit/memory/hipMemoryAllocateCoherent.cc
+++ b/tests/catch/unit/memory/hipMemoryAllocateCoherent.cc
@@ -44,6 +44,12 @@ __global__ void Kernel(float* hostRes, int clkRate) {
 }
 
 TEST_CASE("Unit_hipHostMalloc_CoherentAccess") {
+  hipDeviceProp_t prop;
+  HIP_CHECK(hipGetDeviceProperties(&prop, 0));
+  if (!prop.canMapHostMemory) {
+    HipTest::HIP_SKIP_TEST("Test requires canMapHostMemory support");
+    return;
+  }
   int blocks = 2;
   float* hostRes;
   HIP_CHECK(hipHostMalloc(&hostRes, blocks * sizeof(float),

--- a/tests/catch/unit/memory/hipMemsetFunctional.cc
+++ b/tests/catch/unit/memory/hipMemsetFunctional.cc
@@ -90,6 +90,12 @@ void checkMemset(T value, size_t count, MemsetType memsetType, bool async = fals
   if (mallocType == hipDeviceMalloc_t) {
     HIP_CHECK(hipMalloc(&devPtr, count * sizeof(T)));
   } else if (mallocType == hipHostMalloc_t) {
+    hipDeviceProp_t prop;
+    HIP_CHECK(hipGetDeviceProperties(&prop, 0));
+    if (!prop.canMapHostMemory) {
+      HipTest::HIP_SKIP_TEST("Test requires canMapHostMemory support");
+      return;
+    }
     HIP_CHECK(hipHostMalloc(&devPtr, count * sizeof(T)));
   }
 

--- a/tests/catch/unit/memory/memset.cc
+++ b/tests/catch/unit/memory/memset.cc
@@ -11,6 +11,12 @@ TEST_CASE("Unit_hipMemset_4bytes") {
 }
 
 TEST_CASE("Unit_hipMemset_4bytes_hostMem") {
+  hipDeviceProp_t prop;
+  HIP_CHECK(hipGetDeviceProperties(&prop, 0));
+  if (!prop.canMapHostMemory) {
+    HipTest::HIP_SKIP_TEST("Test requires canMapHostMemory support");
+    return;
+  }
   int* d_a;
   auto res = hipHostMalloc(&d_a, sizeof(int), 0);
   REQUIRE(res == hipSuccess);


### PR DESCRIPTION
Skip tests that require `canMapHostMemory` or managed memory support when the device doesn't advertise these capabilities, instead of failing or crashing.

Affected tests:
- `hipClassKernel`, `hipHostGetDevicePointer`, `hipHostMalloc` (Default, NonCoherent, CoherentAccess)
- `hipMemcpy`, `hipMemcpyAsync` (H2H-H2D-D2H-H2PinMem variants)
- `hipMemsetFunctional`, `memset` (hostMem)
- `hipMemFaultStackAllocation`, `hipMemPrefetchAsync_NonPageSz`, `hipMallocManaged_Basic`