### PR TITLE
Adding in pthreads to tests where needed

### DIFF
--- a/tests/catch/unit/device/CMakeLists.txt
+++ b/tests/catch/unit/device/CMakeLists.txt
@@ -47,7 +47,8 @@ endif()
 hip_add_exe_to_target(NAME DeviceTest
                       TEST_SRC ${TEST_SRC}
                       TEST_TARGET_NAME build_tests
-                      COMPILE_OPTIONS -std=c++14)
+                      COMPILE_OPTIONS -std=c++14
+		      LINKER_LIBS -pthreads)
 
 if(NOT STANDALONE_TESTS)
     add_dependencies(DeviceTest getDeviceCount)

--- a/tests/catch/unit/deviceLib/CMakeLists.txt
+++ b/tests/catch/unit/deviceLib/CMakeLists.txt
@@ -116,7 +116,8 @@ elseif(HIP_PLATFORM MATCHES "spirv")
     hip_add_exe_to_target(NAME UnitDeviceTests
                       TEST_SRC ${TEST_SRC}
                       TEST_TARGET_NAME build_tests
-                      COMPILE_OPTIONS --Wno-deprecated-declarations)
+                      COMPILE_OPTIONS --Wno-deprecated-declarations
+		      LINKER_LIBS -pthreads)
 endif()
 
 if(UNIX AND (NOT HIP_PLATFORM MATCHES "spirv"))

--- a/tests/catch/unit/errorHandling/CMakeLists.txt
+++ b/tests/catch/unit/errorHandling/CMakeLists.txt
@@ -9,4 +9,5 @@ set(TEST_SRC
 hip_add_exe_to_target(NAME ErrorHandlingTest
                       TEST_SRC ${TEST_SRC}
                       TEST_TARGET_NAME build_tests
-                      COMPILE_OPTIONS -std=c++14)
+                      COMPILE_OPTIONS -std=c++14
+		      LINKER_LIBS -pthreads)

--- a/tests/catch/unit/event/CMakeLists.txt
+++ b/tests/catch/unit/event/CMakeLists.txt
@@ -22,4 +22,5 @@ endif()
 
 hip_add_exe_to_target(NAME EventTest
                       TEST_SRC ${TEST_SRC}
-                      TEST_TARGET_NAME build_tests)
+                      TEST_TARGET_NAME build_tests
+		      LINKER_LIBS -pthreads)

--- a/tests/catch/unit/graph/CMakeLists.txt
+++ b/tests/catch/unit/graph/CMakeLists.txt
@@ -84,4 +84,5 @@ set(TEST_SRC
 
 hip_add_exe_to_target(NAME GraphsTest
                       TEST_SRC ${TEST_SRC}
-                      TEST_TARGET_NAME build_tests)
+                      TEST_TARGET_NAME build_tests
+		      LINKER_LIBS -pthreads)

--- a/tests/catch/unit/memory/CMakeLists.txt
+++ b/tests/catch/unit/memory/CMakeLists.txt
@@ -184,4 +184,5 @@ endif()
 
 hip_add_exe_to_target(NAME MemoryTest
                       TEST_SRC ${TEST_SRC}
-                      TEST_TARGET_NAME build_tests)
+                      TEST_TARGET_NAME build_tests
+		      LINKER_LIBS -pthreads)

--- a/tests/catch/unit/multiThread/CMakeLists.txt
+++ b/tests/catch/unit/multiThread/CMakeLists.txt
@@ -7,4 +7,5 @@ set(TEST_SRC
 
 hip_add_exe_to_target(NAME MultiThreadTest
                       TEST_SRC ${TEST_SRC}
-                      TEST_TARGET_NAME build_tests)
+                      TEST_TARGET_NAME build_tests
+		      LINKER_LIBS -pthreads)

--- a/tests/catch/unit/stream/CMakeLists.txt
+++ b/tests/catch/unit/stream/CMakeLists.txt
@@ -51,4 +51,5 @@ endif()
 hip_add_exe_to_target(NAME StreamTest
                       TEST_SRC ${TEST_SRC}
                       TEST_TARGET_NAME build_tests
-                      COMPILE_OPTIONS -std=c++17)
+                      COMPILE_OPTIONS -std=c++17
+		      LINKER_LIBS -pthreads)

--- a/tests/catch/unit/streamperthread/CMakeLists.txt
+++ b/tests/catch/unit/streamperthread/CMakeLists.txt
@@ -10,4 +10,5 @@ set(TEST_SRC
 
 hip_add_exe_to_target(NAME StreamPerThreadTest
                       TEST_SRC ${TEST_SRC}
-                      TEST_TARGET_NAME build_tests)
+                      TEST_TARGET_NAME build_tests
+		      LINKER_LIBS -pthreads)


### PR DESCRIPTION
This is to fix https://github.com/CHIP-SPV/chipStar/issues/1204 . It adds in a link of `-pthread` to the unit tests that use threads but don't link it in. Without linking in `-pthread` the unit tests fail to build on Aurora.