### PR TITLE
fix: include spirv platform in clang branch of run_hipcc.cmake

### DIFF
--- a/cmake/FindHIP/run_hipcc.cmake
+++ b/cmake/FindHIP/run_hipcc.cmake
@@ -66,7 +66,7 @@ execute_process(COMMAND ${HIP_HIPCONFIG_EXECUTABLE} --compiler OUTPUT_VARIABLE H
 execute_process(COMMAND ${HIP_HIPCONFIG_EXECUTABLE} --runtime OUTPUT_VARIABLE HIP_RUNTIME OUTPUT_STRIP_TRAILING_WHITESPACE)
 if(NOT host_flag)
     set(__CC ${HIP_HIPCC_EXECUTABLE})
-    if("${HIP_PLATFORM}" STREQUAL "amd")
+    if("${HIP_PLATFORM}" STREQUAL "amd" OR "${HIP_PLATFORM}" STREQUAL "spirv")
         if("${HIP_COMPILER}" STREQUAL "clang")
             if(NOT "x${HIP_CLANG_PATH}" STREQUAL "x")
                 set(ENV{HIP_CLANG_PATH} ${HIP_CLANG_PATH})


### PR DESCRIPTION
## Summary

- `run_hipcc.cmake` checked only `HIP_PLATFORM == "amd"` to enter the clang compiler branch; chipStar sets `HIP_PLATFORM=spirv`, so it fell into the `else` (nvcc) branch
- For shared libraries the nvcc branch appends `--shared -Xcompiler '-fPIC'`; when clang receives the quoted `''-fPIC''` as a positional argument it fails: `clang++: error: no such file or directory: ''-fPIC''`
- Fix: extend the condition to also match `spirv`

## Root cause

```cmake
# before
if("${HIP_PLATFORM}" STREQUAL "amd")

# after
if("${HIP_PLATFORM}" STREQUAL "amd" OR "${HIP_PLATFORM}" STREQUAL "spirv")
```

## Reproducer

Found while building [SeisSol](https://github.com/SeisSol/SeisSol) with chipStar. SeisSol's Device submodule uses `hip_add_library(... SHARED)` with `HIP_SOURCE_PROPERTY_FORMAT` set, which routes compilation through `run_hipcc.cmake`. A regression test is included in the companion chipStar PR.

## Test plan

- [ ] Build a `SHARED` HIP library via `hip_add_library()` with `HIP_SOURCE_PROPERTY_FORMAT` on chipStar (`HIP_PLATFORM=spirv`) — should compile without `-fPIC` quoting errors
- [ ] Existing AMD (`HIP_PLATFORM=amd`) and CUDA (`HIP_PLATFORM=nvidia`) builds unaffected