### PR TITLE
Adding in needed hipunregister in Unit_hipFreeNegativeHost

### DIFF
--- a/tests/catch/unit/memory/hipFree.cc
+++ b/tests/catch/unit/memory/hipFree.cc
@@ -159,6 +159,7 @@ TEST_CASE("Unit_hipFreeNegativeHost") {
     auto flag = GENERATE(hipHostRegisterDefault, hipHostRegisterPortable, hipHostRegisterMapped);
     HIP_CHECK(hipHostRegister((void*)hostPtr, sizeof(char), flag));
     HIP_CHECK_ERROR(hipHostFree(hostPtr), hipErrorInvalidValue);
+    HIP_CHECK(hipHostUnregister((void*)hostPtr));
     delete hostPtr;
   }
 }


### PR DESCRIPTION
This is to resolve https://github.com/CHIP-SPV/HIP/issues/14 .

This test

[HIP/tests/catch/unit/memory/hipFree.cc](https://github.com/CHIP-SPV/HIP/blob/c18dd4bdb57e0ae4244fdb044c495698fba3c064/tests/catch/unit/memory/hipFree.cc#L160)

is wrong. It should hipHostUnregister the memory, since it is called for each flag in GENERATE. In unfortunate cases, the hostPtr will be the same address, and it will fail since it's trying to re-register a pointer it already registered. By the spec it should fail with [hipErrorHostMemoryAlreadyRegistered](https://rocm.docs.amd.com/projects/HIP/en/latest/reference/error_codes.html#term-hipErrorHostMemoryAlreadyRegistered).

The newer version of hip-tests has this fixed: https://github.com/ROCm/hip-tests/blob/d01e1f96059edc25600eb13434d7e2b71c09af01/catch/unit/memory/hipFree.cc#L163